### PR TITLE
Make weather tracking optional

### DIFF
--- a/assets/js/weather.js
+++ b/assets/js/weather.js
@@ -24,14 +24,26 @@ const key = `${CONFIG.weatherKey}`;
 setPosition();
 
 function setPosition(position) {
-  getWeather();
+  if (!CONFIG.trackLocation || !navigator.geolocation) {
+    if (CONFIG.trackLocation) {
+      console.error('Geolocation not available');
+    }
+    getWeather(CONFIG.defaultLatitude, CONFIG.defaultLongitude);
+    return;
+  }
+  navigator.geolocation.getCurrentPosition(
+    (pos) => {
+      getWeather(pos.coords.latitude.toFixed(3), pos.coords.longitude.toFixed(3));
+    }, (err) => {
+      console.error(err);
+      getWeather(CONFIG.defaultLatitude, CONFIG.defaultLongitude);
+    }
+  )
 }
 
 // Get the Weather data
-function getWeather() {
-  if(navigator.geolocation) {
-    navigator.geolocation.getCurrentPosition(function(a) {
-      let api = `https://api.openweathermap.org/data/2.5/weather?lat=${a.coords["latitude"]}&lon=${a.coords["longitude"]}&appid=${key}`;
+function getWeather(latitude, longitude) {
+  let api = `https://api.openweathermap.org/data/2.5/weather?lat=${latitude}&lon=${longitude}&appid=${key}`;
 
   console.log(api);
 
@@ -50,8 +62,6 @@ function getWeather() {
     .then(function () {
       displayWeather();
     });
-  });
- }
 }
 
 // Display Weather info

--- a/config.js
+++ b/config.js
@@ -26,8 +26,9 @@ const CONFIG = {
   weatherKey: 'InsertYourAPIKeyHere123456',
   weatherIcons: 'OneDark', // 'Nord', 'Dark', 'White'
   weatherUnit: 'C',
-  weatherLatitude: '37.774929',
-  weatherLongitude: '-122.419418',
+  trackLocation: false, // If false or an error occurs, the app will use the lat/lon below
+  defaultLatitude: '37.775',
+  defaultLongitude: '-122.419',
 
   // ┌─┐┌─┐┬─┐┌┬┐┌─┐
   // │  ├─┤├┬┘ ││└─┐


### PR DESCRIPTION
Some people may be reluctant to allow location tracking. Additionally, on Firefox, one can't save tracking preferences for files if they load Bento from a file, so the prompt on every load can be annoying if the tracking isn't optional.